### PR TITLE
(enhancement) cache data for latency boost

### DIFF
--- a/src/controllers/create_comment.ctrl.ts
+++ b/src/controllers/create_comment.ctrl.ts
@@ -1,7 +1,9 @@
-import { Req, Res } from "../api_contracts/create_movie_comment.ctrl.contract"
-import { getStarWarsById } from '../utils/request.utils'
-import { MovieComment } from '../entities/comments.entity';
+import { Req, Res } from '../api_contracts/create_movie_comment.ctrl.contract'
+import { getStarWarsById, IResponse } from '../utils/request.utils'
+import { MovieComment } from '../entities/comments.entity'
 import getCommentRepository from '../entities/comments.entity'
+import { getKey, setKey } from '../utils/cache_data.utils'
+import envs from '../envs'
 
 export default async function createMovieCommentCtrl(req: Req): Res {
     const commentData = req.body.comment
@@ -19,7 +21,13 @@ export default async function createMovieCommentCtrl(req: Req): Res {
         options: { status: 400 },
         data: null
     }
-    const movie = await getStarWarsById(+req.params.id)
+    let movie: IResponse
+    if (getKey(`${envs.swapiBaseUrl}/films/${+req.params.id}`)) {
+        movie = getKey(`${envs.swapiBaseUrl}/films/${+req.params.id}`)
+    } else {
+        movie = await getStarWarsById(+req.params.id)
+        setKey(`${envs.swapiBaseUrl}/films/${+req.params.id}`, movie)
+    }
     if (!movie.success) return movie
     if (!movie.data) return {
         ...movie,

--- a/src/controllers/get_movie.ctrl.ts
+++ b/src/controllers/get_movie.ctrl.ts
@@ -1,9 +1,17 @@
-import { Req, Res } from "../api_contracts/get_movie.ctrl.contract"
-import { getStarWarsById } from '../utils/request.utils';
-import getCommentRepository from "../entities/comments.entity";
+import { Req, Res } from '../api_contracts/get_movie.ctrl.contract'
+import { getStarWarsById, IResponse } from '../utils/request.utils'
+import getCommentRepository from '../entities/comments.entity'
+import envs from '../envs'
+import { getKey, setKey } from '../utils/cache_data.utils'
 
 export default async function getMovieCtrl(req: Req): Res {
-    const movie = await getStarWarsById(+req.params.id)
+    let movie: IResponse
+    if (getKey(`${envs.swapiBaseUrl}/films/${+req.params.id}`)) {
+        movie = getKey(`${envs.swapiBaseUrl}/films/${+req.params.id}`)
+    } else {
+        movie = await getStarWarsById(+req.params.id)
+        setKey(`${envs.swapiBaseUrl}/films/${+req.params.id}`, movie)
+    }
     if (!movie.success) return movie
     if (!movie.data) return {
         ...movie,

--- a/src/controllers/get_movie_comments.ctrl.ts
+++ b/src/controllers/get_movie_comments.ctrl.ts
@@ -1,9 +1,17 @@
 import { Req, Res } from '../api_contracts/get_movie_comments.ctrl.contract'
-import { getStarWarsById } from '../utils/request.utils'
+import { getStarWarsById, IResponse } from '../utils/request.utils'
 import getCommentRepository from '../entities/comments.entity'
+import { getKey, setKey } from '../utils/cache_data.utils'
+import envs from '../envs'
 
 export default async function getMovieCommentsCtrl(req: Req): Res {
-    const movie = await getStarWarsById(+req.params.id)
+    let movie: IResponse
+    if (getKey(`${envs.swapiBaseUrl}/films/${+req.params.id}`)) {
+        movie = getKey(`${envs.swapiBaseUrl}/films/${+req.params.id}`)
+    } else {
+        movie = await getStarWarsById(+req.params.id)
+        setKey(`${envs.swapiBaseUrl}/films/${+req.params.id}`, movie)
+    }
     if (!movie.success) return movie
     if (!movie.data) return {
         ...movie,

--- a/src/controllers/get_movies.ctrl.ts
+++ b/src/controllers/get_movies.ctrl.ts
@@ -1,9 +1,17 @@
 import { Res } from '../api_contracts/get_movies.ctrl.contract'
-import { getStarWars } from '../utils/request.utils'
-import getCommentRepository from '../entities/comments.entity';
+import { getStarWars, IResponse } from '../utils/request.utils'
+import getCommentRepository from '../entities/comments.entity'
+import envs from '../envs'
+import { getKey, setKey } from '../utils/cache_data.utils'
 
 export default async function getMoviesCtrl(): Res {
-    const movies = await getStarWars()
+    let movies: IResponse
+    if (getKey(`${envs.swapiBaseUrl}/films/`)) {
+        movies = getKey(`${envs.swapiBaseUrl}/films/`)
+    } else {
+        movies = await getStarWars()
+        setKey(`${envs.swapiBaseUrl}/films/`, movies)
+    }
     if (!movies.success) return movies
     const moviesResult = []
     for (const movie of movies.data.movies.results) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ export const startServer = async (config: ServerConfig) => {
     app.use(express.json())
     app.use(express.urlencoded({ extended: true }))
     app.set('trust proxy', true)
-    app.use(logger('combined'))
+    app.use(logger('tiny'))
 
     config.routes.forEach((route) => {
         app[route.method](route.path, async (req: Request, res: Response) => {

--- a/src/utils/cache_data.utils.ts
+++ b/src/utils/cache_data.utils.ts
@@ -1,0 +1,12 @@
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const cacheData: { [key: string]: any} = {}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const setKey = (key: string, value: any) => {
+    cacheData[key] = value
+}
+
+export const getKey = (key: string) => {
+    return cacheData[key]
+}

--- a/src/utils/request.utils.ts
+++ b/src/utils/request.utils.ts
@@ -72,7 +72,7 @@ export async function getStarWarsCharacter(url: string): Promise<IResponse> {
     }
 }
 
-interface IResponse {
+export interface IResponse {
     success: boolean
     message: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
1. Why cache data? - Basically the API we rely on doesn't change over time, so caching the data is safe. Also the request rediced from over 1800ms to less than 25ms which is super great.
2. Why cache only data gotten from request? - Since data gotten from our database can change very fast, we can decide not to cache it as there will be alot of read and write operations to the cache object which can make reading from our cache object slow(we do not want this)
3. Why not use a standard caching software like redis? Cost 😞. Cost is an important parameter when doing something. Since this is a relatively small project having an object that stores to memory and goes back to an empty object when the server restarts is fine. And since dependency injection as been setup for our caching, we can easily switch to something better in the future🤩.